### PR TITLE
correction sur commande maj à trouver

### DIFF
--- a/utils/majATrouver.js
+++ b/utils/majATrouver.js
@@ -28,6 +28,9 @@ fs.readFile("data_shared/motsATrouve.txt", "UTF8", function (erreur, contenu) {
         .trim()
         .replace(/^\s+|\s+$/g, "")
     )
+    .filter(function (el) {
+      return el.length > 0;
+    })
     .forEach((mot, numeroMot) =>
       new Promise((resolve, reject) => {
         let datePartie = new Date(instanceConfiguration.default.dateOrigine);


### PR DESCRIPTION
Il y a un ligne vide à la fin du fichier `data_shared/motsATrouve.txt`,
on pouvait donc se retrouver lors de la génération des fichiers de mots
avec des fichiers vides.

Pour éviter cela on enlève les entrées vides du tableau.