### PR TITLE
correction du build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 
+# le fichier nettoyage.js utilise le fichier instanceConfiguration.js, il a donc besoin que les fichiers typescript soient buildés
+./node_modules/.bin/tsc
+
 ./utils/nettoyage.js
+
+# le fichier nettoyage.js écrit des fichiers typescript, on rebuilde donc afin de générer les fichiers js correspondants
 ./node_modules/.bin/tsc


### PR DESCRIPTION
Lors du build on avait cette erreur :

```
 2022-05-28T15:22:56+02:00 code: 'MODULE_NOT_FOUND',
2022-05-28T15:22:56+02:00 at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
2022-05-28T15:22:56+02:00 at Function.Module._load (node:internal/modules/cjs/loader:778:27)
2022-05-28T15:22:56+02:00 Require stack:
2022-05-28T15:22:56+02:00 '/home/bas/app_327c43fe-71bf-4674-b251-a52799da99cb/utils/nettoyage.js'
2022-05-28T15:22:56+02:00 at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12) {
2022-05-28T15:22:56+02:00 at Function.Module._load (node:internal/modules/cjs/loader:822:12)
2022-05-28T15:22:56+02:00 at Module._compile (node:internal/modules/cjs/loader:1105:14)
2022-05-28T15:22:56+02:00 requireStack: [
2022-05-28T15:22:56+02:00 at Module.load (node:internal/modules/cjs/loader:981:32)
2022-05-28T15:22:56+02:00 at require (node:internal/modules/cjs/helpers:102:18)
2022-05-28T15:22:56+02:00 at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
2022-05-28T15:22:56+02:00 throw err;
2022-05-28T15:22:56+02:00 at Object.<anonymous> (/home/bas/app_327c43fe-71bf-4674-b251-a52799da99cb/utils/nettoyage.js:9:29)
2022-05-28T15:22:56+02:00 at Module.require (node:internal/modules/cjs/loader:1005:19)
2022-05-28T15:22:56+02:00 - /home/bas/app_327c43fe-71bf-4674-b251-a52799da99cb/utils/nettoyage.js
2022-05-28T15:22:56+02:00 Error: Cannot find module '../public/js/instanceConfiguration'
2022-05-28T15:22:56+02:00 ^
2022-05-28T15:22:56+02:00 }
```

Cela car le fichier instanceConfiguration.js n'existe pas si on a pas lancé le build typescript.

Vu que les fichiers  du type `/js/mots/listeMotsProposables.7.O.js`, en front on avait une erreur comme quoi il n'y avait pas de mot aujoud'hui.

On lance donc un premier build avant le nettoyage