### PR TITLE
on supprime une référence à sutom dans les variables d'environnement

### DIFF
--- a/ts/server.ts
+++ b/ts/server.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import InstanceConfiguration from "./instanceConfiguration";
 
 const app = express();
-const port = parseInt(String(process.env.SUTOM_PORT), 10) || 4000;
+const port = parseInt(String(process.env.PUFA_PORT), 10) || 4000;
 
 (async () => {
   app.use("/", express.static("public/"));


### PR DESCRIPTION
cf #8

La variable PUFA_PORT a déjà été configurée coté Clever.
La variable SUTOM_PORT pourra être supprimée après le merge/déploiement
de cette PR.