### PR TITLE
remise à zéro PUFA

### DIFF
--- a/ts/instanceConfiguration.ts
+++ b/ts/instanceConfiguration.ts
@@ -1,6 +1,6 @@
 export default class InstanceConfiguration {
   public static readonly dateOrigine = new Date(2022, 5, 21); // Attention, c'est du js/ts, donc pour le mois, il faut faire -1, Janvier = 0 !
-  public static readonly idPartieParDefaut = "34ccc522-c264-4e51-b293-fd5bd60ef7aa";
+  public static readonly idPartieParDefaut = "bc1d91c6-b232-4924-9647-de13dbb57de9";
 
   public static readonly tailleMin = 6;
 


### PR DESCRIPTION
en prévision du lancement public, on fait en sorte d'avoir un numéro de partie plus proche de la date de lancement.

a la main : 
* je supprimerais data_shared/motsATrouve.txt
* et tous les fichiers dans public/mots